### PR TITLE
Adds support for passing environment variables that can configure an …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
 FROM tomcat:9-jdk11-openjdk
 
+# escape \
 ENV TOMCAT_USERS_FILE=$CATALINA_HOME/conf/tomcat-users.xml \
+    FEDORA_ADMIN_USERNAME=fedoraAdmin \
     FEDORA_ADMIN_PASSWORD=fedoraAdmin \
-    FCREPO_OCFL_STAGING_DIR=/var/lib/fcrepo/staging \
-    FCREPO_OCFL_STORAGE_ROOT_DIR=/var/lib/fcrepo/ocfl \
-    FCREPO_OCFL_WORK_DIR=/var/lib/fcrepo/work \
+    FCREPO_HOME=/var/lib/fcrepo \
+    FCREPO_OCFL_STAGING=/var/lib/fcrepo/staging \
+    FCREPO_OCFL_ROOT=/var/lib/fcrepo/ocfl-root  \
+    FCREPO_OCFL_TEMP=/var/lib/fcrepo/ocfl-temp \
+    FCREPO_ACTIVEMQ_DIRECTORY=/var/lib/fcrepo/activemq \
+    FCREPO_DB_URL="jdbc:h2:/var/lib/fcrepo/data/fcrepo-h2\;FILE_LOCK=SOCKET"  \
+    FCREPO_DB_USERNAME="" \
+    FCREPO_DB_PASSWORD="" \
     FCREPO_ACTIVEMQ_DIRECTORY=/var/lib/fcrepo/activemq \
     FCREPO_AUDIT_CONTAINER=/audit
-
-# Unclear if still used:
-# fcrepo.home=/var/lib/fcrepo
-# com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean.default.objectStoreDir=arjuna.common.object.store
-# com.arjuna.ats.arjuna.objectstore.objectStoreDir=arjuna.object.store
 
 # Add webapp, scripts and config files: 
 COPY tomcat/conf/* $CATALINA_HOME/conf/
@@ -23,5 +25,3 @@ RUN chmod 744 $CATALINA_HOME/bin/setenv.sh \
     && mkdir $CATALINA_HOME/webapps/fcrepo
 
 COPY webapp $CATALINA_HOME/webapps/fcrepo
-
-

--- a/README.md
+++ b/README.md
@@ -32,9 +32,13 @@ Variable | Default Value | Description
 -------- | ------------- | -----------
 `CATALINA_OPTS` | none |
 `TOMCAT_USERS_FILE` | `$CATALINA_HOME/conf/tomcat-users.xml` | Specify a custom tomcat-users.xml file with e.g. additional users
-`FCREPO_OCFL_STAGING_DIR` | `/var/lib/fcrepo/staging` | Set fcrepo.ocfl.staging.dir
-`FCREPO_OCFL_STORAGE_ROOT_DIR` | `/var/lib/fcrepo/ocfl` | Set fcrepo.ocfl.storage.root.dir
-`FCREPO_OCFL_WORK_DIR` | `/var/lib/fcrepo/work` | Set fcrepo.ocfl.work.dir
+`FCREPO_HOME` | `/var/lib/fcrepo` | Set fcrepo.home
+`FCREPO_OCFL_STAGING` | `${fcrepo.home}/staging` | Set fcrepo.ocfl.staging
+`FCREPO_OCFL_ROOT` | `${fcrepo.home}/ocfl-root` | Set fcrepo.ocfl.root
+`FCREPO_OCFL_TEMP` | `${fcrepo.home/ocfl-temp` | Set fcrepo.ocfl.temp
+`FCREPO_DB_URL` | none | Set fcrepo.db.url
+`FCREPO_DB_USERNAME` | none | Set fcrepo.db.username
+`FCREPO_DB_PASSWORD` | none | Set fcrepo.db.password
 `FCREPO_AUDIT_CONTAINER` | `/audit` | Set fcrepo.audit.container
 `FCREPO_SPRING_CONFIGURATION` | none | Specify a custom fcrepo.spring.configuration file
 `FCREPO_ACTIVEMQ_CONFIGURATION` | none | Specify a custom fcrepo.activemq.configuration
@@ -42,7 +46,8 @@ Variable | Default Value | Description
 `FCREPO_AUTH_WEBAC_AUTHORIZATION` | none | Specify a custom root WebAC authentication fcrepo.activemq.configuration
 `FCREPO_SPRING_AUDIT_CONFIGURATION` | none | Specify a custom fcrepo.spring.audit.configuration
 `FCREPO_VELOCITY_RUNTIME_LOG` | none | Set fcrepo.velocity.runtime.log
-`FEDORA_ADMIN_PASSWORD` | `fedoraAdmin` | If using the default tomcat-users.xml file: specify a custom password to for the user `fedoraAdmin`
+`FEDORA_ADMIN_USERNAME` | `fedoraAdmin` | If using the default tomcat-users.xml file: specify a custom username for the user `fedoraAdmin`
+`FEDORA_ADMIN_PASSWORD` | `fedoraAdmin` | If using the default tomcat-users.xml file: specify a custom password  for the FEDORA_ADMIN_USERNAME defined above
 `LOGBACK_CONFIGURATIONFILE` | none | Specify a custom logback.configurationFile
 
 For a detailed explanation of the configuration options have a look at [Application Configuration](https://wiki.lyrasis.org/display/FEDORA6x/Application+Configuration) in the Lyrasis Wiki.

--- a/tomcat/bin/setenv.sh
+++ b/tomcat/bin/setenv.sh
@@ -2,14 +2,39 @@
 
 # Add system properties for env variables defined in docker image:
 CATALINA_OPTS="$CATALINA_OPTS \
--Dfile.encoding=UTF-8 \
 -Dorg.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.EnvironmentPropertySource \
--Dfcrepo.ocfl.staging.dir=$FCREPO_OCFL_STAGING_DIR \
--Dfcrepo.ocfl.storage.root.dir=$FCREPO_OCFL_STORAGE_ROOT_DIR \
--Dfcrepo.ocfl.work.dir=$FCREPO_OCFL_WORK_DIR \
+-Dfile.encoding=UTF-8 \
+-Dorg.apache.tomcat.util.digester.REPLACE_SYSTEM_PROPERTIES=true \
 -Dfcrepo.audit.container=$FCREPO_AUDIT_CONTAINER"
 
 # Only add these system properties, if the env variable is defined:
+if [ ! -z "$FCREPO_HOME" ] ; then
+  CATALINA_OPTS="$CATALINA_OPTS -Dfcrepo.home=$FCREPO_HOME"
+fi
+
+if [ ! -z "$FCREPO_OCFL_STAGING" ] ; then
+  CATALINA_OPTS="$CATALINA_OPTS -Dfcrepo.ocfl.staging=$FCREPO_OCFL_STAGING"
+fi
+
+if [ ! -z "$FCREPO_OCFL_ROOT" ] ; then
+  CATALINA_OPTS="$CATALINA_OPTS -Dfcrepo.ocfl.root=$FCREPO_OCFL_ROOT"
+fi
+
+if [ ! -z "$FCREPO_OCFL_TEMP" ] ; then
+  CATALINA_OPTS="$CATALINA_OPTS -Dfcrepo.ocfl.temp=$FCREPO_OCFL_TEMP"
+fi
+
+if [ ! -z "$FCREPO_DB_URL" ] ; then
+  CATALINA_OPTS="$CATALINA_OPTS -Dfcrepo.db.url=$FCREPO_DB_URL"
+fi 
+
+if [ ! -z "$FCREPO_DB_USERNAME" ] ; then
+  CATALINA_OPTS="$CATALINA_OPTS -Dfcrepo.db.user=$FCREPO_DB_USERNAME"
+fi
+
+if [ ! -z "$FCREPO_DB_PASSWORD" ] ; then
+  CATALINA_OPTS="$CATALINA_OPTS -Dfcrepo.db.password=$FCREPO_DB_PASSWORD"
+fi
 
 if [ ! -z "$FCREPO_SPRING_CONFIGURATION" ] ; then
   CATALINA_OPTS="$CATALINA_OPTS -Dfcrepo.spring.configuration=$FCREPO_SPRING_CONFIGURATION"

--- a/tomcat/conf/tomcat-users.xml
+++ b/tomcat/conf/tomcat-users.xml
@@ -42,5 +42,5 @@
   <user username="role1" password="<must-be-changed>" roles="role1"/>
 -->
   <role rolename="fedoraAdmin"/>
-  <user username="fedoraAdmin" password="${FEDORA_ADMIN_PASSWORD}" roles="fedoraAdmin"/>"
+  <user username="${FEDORA_ADMIN_USERNAME}" password="${FEDORA_ADMIN_PASSWORD}" roles="fedoraAdmin"/>"
 </tomcat-users>


### PR DESCRIPTION
…external database.

Also updates the list of available configuration variables and cleans up the Dockerfile
and README.md

JIRA: https://jira.lyrasis.org/browse/FCREPO-3433

## To test mysql on OSX

```
#  build fcrepo4 
# run the fcrepo-docker build script
./build.sh /path/to/fcrepo.war

# start mysql
docker run --name f6-mysql -e MYSQL_ROOT_PASSWORD=root-pw -e MYSQL_DATABASE=fcrepo -e MYSQL_USER=fcrepo-user -e MYSQL_PASSWORD=fcrepo-pw -p 3306:3306 -d mysql:8.0

# start fedora
docker run -p8080:8080 --name fcrepo-6  -e FCREPO_DB_URL=jdbc:mysql://host.docker.internal:3306/fcrepo -e FCREPO_DB_USERNAME=fcrepo-user -e FCREPO_DB_PASSWORD=fcrepo-pw fcrepo/fcrepo:latest
```
Verify that http://localhost:8080/fcrepo/rest is functioning.
Log into database directly and  verify the data is being stored there.


## or postgres:
```
docker run --name f6-postgres -e POSTGRES_USER=fcrepo-user -e POSTGRES_PASSWORD=fcrepo-pw -e POSTGRES_DB=fcrepo -p 5432:5432 -d postgres:12.3

docker run -p8080:8080 --name fcrepo-6  -e FCREPO_DB_URL=jdbc:postgresql://host.docker.internal:5432/fcrepo -e FCREPO_DB_USERNAME=fcrepo-user -e FCREPO_DB_PASSWORD=fcrepo-pw fcrepo/fcrepo:latest
```
Verify that http://localhost:8080/fcrepo/rest is functioning.


## NB: For linux you must use localhost and `--network=host`
In  other words: 
```
docker run --network=host --name f6-mysql -e MYSQL_ROOT_PASSWORD=root-pw -e MYSQL_DATABASE=fcrepo -e MYSQL_USER=fcrepo-user -e MYSQL_PASSWORD=fcrepo-pw -d mysql:8.0
docker run --network=host --name fcrepo-6 -e FCREPO_DB_URL=jdbc:mysql://localhost:3306/fcrepo -e FCREPO_DB_USERNAME=fcrepo-user -e FCREPO_DB_PASSWORD=fcrepo-pw fcrepo/fcrepo:latest
```