### PR TITLE
FCREPO-3846: Activate RemoteIpValve

### DIFF
--- a/tomcat/conf/server.xml
+++ b/tomcat/conf/server.xml
@@ -165,6 +165,9 @@
                prefix="localhost_access_log" suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b" />
 
+        <!-- Detect if Fedora is running behind a reverse proxy -->
+        <Valve className="org.apache.catalina.valves.RemoteIpValve"
+        protocolHeader="X-Forwarded-Proto" />
       </Host>
     </Engine>
   </Service>

--- a/tomcat/conf/server.xml
+++ b/tomcat/conf/server.xml
@@ -167,7 +167,9 @@
 
         <!-- Detect if Fedora is running behind a reverse proxy -->
         <Valve className="org.apache.catalina.valves.RemoteIpValve"
-        protocolHeader="X-Forwarded-Proto" />
+        protocolHeader="X-Forwarded-Proto"
+        hostHeader="X-Forwarded-Host"
+        remoteIpHeader="X-Forwarded-For" />
       </Host>
     </Engine>
   </Service>


### PR DESCRIPTION
This PR activates the RemoteIpValve in Tomcat, that allows Tomcat to detect if it's running behind a reverse proxy that takes care of SSL termination.

I have a local development setup that uses only HTTP. Building an image based on my change doesn't change anything, as expected:

<img width="1023" alt="image" src="https://user-images.githubusercontent.com/7010698/188100037-a551261e-dee9-46da-89be-ddc8a7db89bb.png">

However, for our repository server, using the official v6.2.0 image, the situation looks as follows:

<img width="1013" alt="Screenshot 2022-09-02 at 10 53 49" src="https://user-images.githubusercontent.com/7010698/188104380-c72eb23c-8e45-4931-b4e2-b493ba2badd8.png">

All links in Fedora are generated with HTTP.

Deploying a version with the activated RemoteIpValve fixes the problem.

<img width="1023" alt="Screenshot 2022-09-02 at 11 00 00" src="https://user-images.githubusercontent.com/7010698/188104661-1533c183-c541-4eed-8fe8-bef72e030cc6.png">
