### PR TITLE
Regularly rebuild image of latest release

### DIFF
--- a/.github/workflows/rebuild-latest-stable-image.yml
+++ b/.github/workflows/rebuild-latest-stable-image.yml
@@ -1,0 +1,57 @@
+name: Rebuild latest release image version
+
+on:
+  schedule:
+    - cron: 0 0 * * 1
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  rebuild:
+    name: Rebuild latest release image version
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout main fcrepo repository"
+        uses: actions/checkout@v3
+        with:
+          repository: "fcrepo/fcrepo"
+
+      - name: "Checkout fcrepo Docker repository"
+        uses: actions/checkout@v3
+        with:
+          path: "fcrepo-docker"
+
+      - name: "Get latest release version"
+        id: get_latest_version
+        run: |
+          # https://github.com/actions/checkout/issues/701
+          git fetch --tags origin --unshallow
+          LATEST_RELEASE_TAG=$(git describe --abbrev=0 --exclude="*RC*")
+
+          echo "latest_release_tag=$LATEST_RELEASE_TAG" >> $GITHUB_OUTPUT
+          echo "latest_release_version=${LATEST_RELEASE_TAG//fcrepo-/}" >> $GITHUB_OUTPUT
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: "temurin"
+          java-version: 11
+          cache: "maven"
+
+      - name: "Build fcrepo WAR"
+        run: |
+          git checkout "${{ steps.get_latest_version.outputs.latest_release_tag }}"
+          mvn -B -U clean install
+
+      - name: "Build Docker image"
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          cd fcrepo-docker
+          LATEST_RELEASE_VERSION=${{ steps.get_latest_version.outputs.latest_release_version }}
+          a=( ${LATEST_RELEASE_VERSION//./ } )
+
+          ./build-and-push-to-dockerhub.sh ../fcrepo-webapp/target/fcrepo-webapp-$LATEST_RELEASE_VERSION.war "${a[0]}.${a[1]}.${a[2]}-tomcat9" "${a[0]}.${a[1]}-tomcat9" "${a[0]}-tomcat9"

--- a/.github/workflows/rebuild-latest-stable-image.yml
+++ b/.github/workflows/rebuild-latest-stable-image.yml
@@ -52,6 +52,6 @@ jobs:
         run: |
           cd fcrepo-docker
           LATEST_RELEASE_VERSION=${{ steps.get_latest_version.outputs.latest_release_version }}
-          a=( ${LATEST_RELEASE_VERSION//./ } )
+          VERSION_PARTS=( ${LATEST_RELEASE_VERSION//./ } )
 
-          ./build-and-push-to-dockerhub.sh ../fcrepo-webapp/target/fcrepo-webapp-$LATEST_RELEASE_VERSION.war "${a[0]}.${a[1]}.${a[2]}-tomcat9" "${a[0]}.${a[1]}-tomcat9" "${a[0]}-tomcat9"
+          ./build-and-push-to-dockerhub.sh ../fcrepo-webapp/target/fcrepo-webapp-$LATEST_RELEASE_VERSION.war "${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}-tomcat9" "${VERSION_PARTS[0]}.${VERSION_PARTS[1]}-tomcat9" "${VERSION_PARTS[0]}-tomcat9"


### PR DESCRIPTION
Fixes [FCREPO-3849](https://fedora-repository.atlassian.net/browse/FCREPO-3849) and [FCREPO-3850](https://fedora-repository.atlassian.net/browse/FCREPO-3850).

This PR adds a new GitHub Actions workflow. In a nutshell:

1. It finds the latest Git tag on the main branch for `fcrepo/fcrepo`, excluding tags that include `RC`. For the found tag, we can safely assume it's the latest release of `fcrepo`.
2. Checks out the tag and rebuilds `fcrepo`.
3. Builds the Docker image and pushes three tags, as of now:
    * 6-tomcat9
    * 6.4-tomcat9
    * 6.4.0-tomcat9

The pipeline is triggered:
- when requested using `workflow_dispatch`.
- every Monday.
- on push to `main`.

A successful run looks something like [this](https://github.com/andyundso/fcrepo-docker/actions/runs/4915843761).

Note that this pipeline could be simplified:

1. Merge this repository with the main `fcrepo`, so we don't have to checkout two repository to make this pipeline work.
2. Extend the Dockerfile to also include the `maven build`, so this pipeline's instructions can be simplified.