### PR TITLE
Check for repository variable

### DIFF
--- a/.github/workflows/rebuild-latest-stable-image.yml
+++ b/.github/workflows/rebuild-latest-stable-image.yml
@@ -23,15 +23,20 @@ jobs:
         with:
           path: "fcrepo-docker"
 
-      - name: "Get latest release version"
-        id: get_latest_version
+      - name: "Check for preset tag"
         run: |
-          # https://github.com/actions/checkout/issues/701
-          git fetch --tags origin --unshallow
-          LATEST_RELEASE_TAG=$(git describe --abbrev=0 --exclude="*RC*")
-
-          echo "latest_release_tag=$LATEST_RELEASE_TAG" >> $GITHUB_OUTPUT
-          echo "latest_release_version=${LATEST_RELEASE_TAG//fcrepo-/}" >> $GITHUB_OUTPUT
+          if [[ -n "${{ vars.FCREPO_SPECIAL_RELEASE_TAG}}" ]]; then
+            FCREPO_LATEST_RELEASE_TAG=${{ vars.FCREPO_SPECIAL_RELEASE_TAG }}
+            echo "FCREPO_LATEST_RELEASE_TAG=${FCREPO_LATEST_RELEASE_TAG}" >> $GITHUB_ENV
+            FCREPO_LATEST_RELEASE_VERSION=${FCREPO_LATEST_RELEASE_TAG//fcrepo-/}
+            echo "FCREPO_LATEST_RELEASE_VERSION=${FCREPO_LATEST_RELEASE_VERSION}"  >> $GITHUB_ENV
+          else
+            # https://github.com/actions/checkout/issues/701
+            git fetch --tags origin --unshallow
+            LATEST_RELEASE_TAG=$(git describe --abbrev=0 --exclude="*RC*")
+            echo "FCREPO_LATEST_RELEASE_TAG=$LATEST_RELEASE_TAG" >> $GITHUB_ENV
+            echo "FCREPO_LATEST_RELEASE_VERSION=${LATEST_RELEASE_TAG//fcrepo-/}" >> $GITHUB_ENV
+          fi
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -42,8 +47,9 @@ jobs:
 
       - name: "Build fcrepo WAR"
         run: |
-          git checkout "${{ steps.get_latest_version.outputs.latest_release_tag }}"
+          git checkout "${{ env.FCREPO_LATEST_RELEASE_TAG }}"
           mvn -B -U clean install
+
 
       - name: "Build Docker image"
         env:
@@ -51,7 +57,7 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           cd fcrepo-docker
-          LATEST_RELEASE_VERSION=${{ steps.get_latest_version.outputs.latest_release_version }}
+          LATEST_RELEASE_VERSION=${{ env.FCREPO_LATEST_RELEASE_VERSION }}
           VERSION_PARTS=( ${LATEST_RELEASE_VERSION//./ } )
 
           ./build-and-push-to-dockerhub.sh ../fcrepo-webapp/target/fcrepo-webapp-$LATEST_RELEASE_VERSION.war "${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}-tomcat9" "${VERSION_PARTS[0]}.${VERSION_PARTS[1]}-tomcat9" "${VERSION_PARTS[0]}-tomcat9"


### PR DESCRIPTION
This PR starts a check for a Repository Variable called `FCREPO_SPECIAL_RELEASE_TAG` which has the format of `fcrepo-X.Y.Z` and matches a tag on the fcrepo/fcrepo repository.

You would set this variable on this repository under 
> Settings -> Security -> Secrets & Variables -> Actions

On the "Variables" tab, you would add a "Repository Variable" of `FCREPO_SPECIAL_RELEASE_TAG` and value of the release to be building.

For instance, right now it should be `fcrepo-6.4.1`.

Then when this runs it will use that variable instead of trying to find the most recent tagged version. Once we release a newly tagged version, the repository variable can be deleted and the action will revert to normal behaviour. 