### PR TITLE
Make encodedSolidusHandling configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM tomcat:9-jdk11-temurin
 # escape \
 ENV TOMCAT_USERS_FILE=$CATALINA_HOME/conf/tomcat-users.xml \
     FEDORA_ADMIN_USERNAME=fedoraAdmin \
-    FEDORA_ADMIN_PASSWORD=fedoraAdmin
+    FEDORA_ADMIN_PASSWORD=fedoraAdmin \
+    ENCODED_SOLIDUS_HANDLING=reject
 
 # Add webapp, scripts and config files: 
 COPY tomcat/conf/* $CATALINA_HOME/conf/

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Variable | Default Value | Description
 `FEDORA_ADMIN_USERNAME` | `fedoraAdmin` | If using the default tomcat-users.xml file: specify a custom username for the user `fedoraAdmin`
 `FEDORA_ADMIN_PASSWORD` | `fedoraAdmin` | If using the default tomcat-users.xml file: specify a custom password  for the FEDORA_ADMIN_USERNAME defined above
 `LOGBACK_CONFIGURATIONFILE` | none | Specify a custom logback.configurationFile
+`ENCODED_SOLIDUS_HANDLING` | `reject` | Sets the Tomcat `encodedSolidusHandling` property which defines how URLs with `%2F` are handled, valid values are `reject`, `decode` or `passthrough`. 
 
 Use the CATALINA_OPTS environment variable to pass in Java options (-Dname=value). You may also pass all your options via a properties file
 using the "fcrepo.config.file" option.  For example: 

--- a/build-and-push-to-dockerhub.sh
+++ b/build-and-push-to-dockerhub.sh
@@ -67,8 +67,8 @@ if [ $PUSH -eq 1 ]; then
     read -s DOCKER_PASSWORD
     echo ""
     echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    docker buildx create --use > /dev/null
 fi
+docker buildx create --use > /dev/null
 platforms=linux/arm64,linux/amd64
 
 # build and push images

--- a/build-and-push-to-dockerhub.sh
+++ b/build-and-push-to-dockerhub.sh
@@ -2,11 +2,37 @@
 
 # exit when any command fails:
 set -e
+# line by line tracing
+#set -x
+
+function usage {
+  echo "Usage: $(basename $0) <fcrepo-x.y.z.war> <tags>+"
+  echo "    <fcrepo-x.y.z.war> : path to the fcrepo war file to build with"
+  echo "    <tags> : one or more tags for the image (must not be 'latest' or empty"
+}
+
+
+if [ $# -lt 1 ]; then
+  usage
+  exit 1
+fi
+if [ $# -ge 1 ]; then
+  for opt in "$@"; do
+    case $opt in
+      "-h"|"--help")
+        usage
+        exit 1
+        ;;
+     esac
+  done
+fi
 
 FCREPO_WEBAPP_FULL_PATH="$1"
+TAGS=( "${@:2}" )
+
 FCREPO_WEBAPP_FILE=$(basename "$FCREPO_WEBAPP_FULL_PATH")
 
-for docker_tag in "${@:2}"
+for docker_tag in "${TAGS[@]}"
 do
     # Check that valid tag is supplied. If not, fail
     if [ "latest" == "${docker_tag}" ] || [ -z "${docker_tag}" ]
@@ -24,14 +50,19 @@ mkdir ./webapp
 unzip -q -d ./webapp "$FCREPO_WEBAPP_FULL_PATH"
 
 # authenticate with docker hub and then push images:
+echo -n "Enter hub.docker.com username ->"
+read DOCKER_USERNAME
+echo -n "Enter hub.docker.com password ->"
+read -s DOCKER_PASSWORD
+echo ""
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-docker buildx create --use
+docker buildx create --use > /dev/null
 platforms=linux/arm64,linux/amd64
 
 # build and push images
-for docker_tag in "${@:2}"
+for docker_tag in "${TAGS[@]}"
 do
-    echo "Building and pushing $docker_tag ..."
-    docker buildx build --platform ${platforms} --push  -t fcrepo/fcrepo:$docker_tag .
-    echo "Build and push complete for $docker_tag"
+    echo -n "Building and pushing $docker_tag ..."
+    docker buildx build --quiet --platform ${platforms} --push -t fcrepo/fcrepo:$docker_tag .
+    echo " complete ($docker_tag)"
 done

--- a/tomcat/conf/server.xml
+++ b/tomcat/conf/server.xml
@@ -68,7 +68,9 @@
     -->
     <Connector port="8080" protocol="HTTP/1.1"
                connectionTimeout="20000"
-               redirectPort="8443" />
+               redirectPort="8443"
+               encodedSolidusHandling="${ENCODED_SOLIDUS_HANDLING}" />
+
     <!-- A "Connector" using the shared thread pool-->
     <!--
     <Connector executor="tomcatThreadPool"


### PR DESCRIPTION
To allow the use of `%2F` in a URL you must set `encodedSolidusHandling` to either `decode` or `passthrough` instead of the default (`reject`).

This sets an environment variable `ENCODED_SOLIDUS_HANDLING` to `reject` and allows users to change it.

This also does some quality of life work on the `build-and-push-to-dockerhub.sh`.

It allows people to provide `-h` or `--help` to get the usage information.

It also prompts for the hub.docker login information instead of having to set it before hand.