### PR TITLE
Switch to tomcat:9-jre11-temurin as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9-jdk11-openjdk
+FROM tomcat:9-jre11-temurin
 
 # escape \
 ENV TOMCAT_USERS_FILE=$CATALINA_HOME/conf/tomcat-users.xml \


### PR DESCRIPTION
The previously used tag `9-jdk11-openjdk` hasn't been updated for a long time. This commit switches to a officially supported tag of the tomcat Docker image.

Resolves: https://fedora-repository.atlassian.net/browse/FCREPO-4013

Open question: Should the Docker image `tomcat:9-jre11` be used instead, to possible avoid this problem in the future (if Eclipse Temurin variant of the tomcat Docker image ever get unmaintained)?