### PR TITLE
bumping tomcat major version from 9 to 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9-jdk11-temurin
+FROM tomcat:10-jdk21-temurin
 
 # escape \
 ENV TOMCAT_USERS_FILE=$CATALINA_HOME/conf/tomcat-users.xml \


### PR DESCRIPTION
To support Fedora 7 dockerhub images, we've bumped tomcat from 9 to 10