### PR TITLE
Push Docker weekly built images to Docker Hub, derive Tomcat major version from Dockerfile

### DIFF
--- a/.github/workflows/rebuild-latest-stable-image.yml
+++ b/.github/workflows/rebuild-latest-stable-image.yml
@@ -60,4 +60,4 @@ jobs:
           LATEST_RELEASE_VERSION=${{ env.FCREPO_LATEST_RELEASE_VERSION }}
           VERSION_PARTS=( ${LATEST_RELEASE_VERSION//./ } )
 
-          ./build-and-push-to-dockerhub.sh ../fcrepo-webapp/target/fcrepo-webapp-$LATEST_RELEASE_VERSION.war "${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}-tomcat9" "${VERSION_PARTS[0]}.${VERSION_PARTS[1]}-tomcat9" "${VERSION_PARTS[0]}-tomcat9"
+          ./build-and-push-to-dockerhub.sh --push ../fcrepo-webapp/target/fcrepo-webapp-$LATEST_RELEASE_VERSION.war "${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}-tomcat9" "${VERSION_PARTS[0]}.${VERSION_PARTS[1]}-tomcat9" "${VERSION_PARTS[0]}-tomcat9"

--- a/.github/workflows/rebuild-latest-stable-image.yml
+++ b/.github/workflows/rebuild-latest-stable-image.yml
@@ -59,5 +59,6 @@ jobs:
           cd fcrepo-docker
           LATEST_RELEASE_VERSION=${{ env.FCREPO_LATEST_RELEASE_VERSION }}
           VERSION_PARTS=( ${LATEST_RELEASE_VERSION//./ } )
+          TOMCAT_MAJOR_VERSION=$(sed -nr 's/^FROM tomcat:([[:digit:]]+)(-.*)?$/\1/p' Dockerfile)
 
-          ./build-and-push-to-dockerhub.sh --push ../fcrepo-webapp/target/fcrepo-webapp-$LATEST_RELEASE_VERSION.war "${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}-tomcat9" "${VERSION_PARTS[0]}.${VERSION_PARTS[1]}-tomcat9" "${VERSION_PARTS[0]}-tomcat9"
+          ./build-and-push-to-dockerhub.sh --push ../fcrepo-webapp/target/fcrepo-webapp-$LATEST_RELEASE_VERSION.war "${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}-tomcat${TOMCAT_MAJOR_VERSION}" "${VERSION_PARTS[0]}.${VERSION_PARTS[1]}-tomcat${TOMCAT_MAJOR_VERSION}" "${VERSION_PARTS[0]}-tomcat${TOMCAT_MAJOR_VERSION}"


### PR DESCRIPTION
**JIRA Ticket**: [FCREPO-4081](https://fedora-repository.atlassian.net/browse/FCREPO-4080)

# What does this Pull Request do?

Runs the script `build-and-push-to-dockerhub.sh` with the command line flag `--push` and makes sure the actual Tomcat major version is used for the Docker tags .

The script is executed at the end of the deploy job in the step "Deploy Docker image".Without the command line flag `--push`, the built Docker images are not pushed to Docker Hub.

Note: **This PR must not be merged before Fedora 7 has been released.** Otherwise, the Fedora 6 Docker image would be overwritten with a Image that uses Tomcat 10 instead of 9.

# Interested parties
@fcrepo/committers
