### PR TITLE
Fix build pipeline

### DIFF
--- a/.github/workflows/rebuild-latest-stable-image.yml
+++ b/.github/workflows/rebuild-latest-stable-image.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout main fcrepo repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: "fcrepo/fcrepo"
 
       - name: "Checkout fcrepo Docker repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: "fcrepo-docker"
 
@@ -38,18 +38,17 @@ jobs:
             echo "FCREPO_LATEST_RELEASE_VERSION=${LATEST_RELEASE_TAG//fcrepo-/}" >> $GITHUB_ENV
           fi
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: 11
+          java-version: 21
           cache: "maven"
 
       - name: "Build fcrepo WAR"
         run: |
           git checkout "${{ env.FCREPO_LATEST_RELEASE_TAG }}"
-          mvn -B -U clean install
-
+          mvn -U -B -Dmaven.test.skip=true install
 
       - name: "Build Docker image"
         env:


### PR DESCRIPTION
Update used actions, switch to Java 21, skip any tests when building fcrepo-webapp
    
- Use the same actions for checkout and Java setup as in fcrepo/fcrepo
- Switch to Java 21
- Skip compilation and execution of tests