### PR TITLE
reverting to tomcat 9 and jdk11 for fedora6-maintenance branch

### DIFF
--- a/.github/workflows/rebuild-latest-stable-image.yml
+++ b/.github/workflows/rebuild-latest-stable-image.yml
@@ -38,11 +38,11 @@ jobs:
             echo "FCREPO_LATEST_RELEASE_VERSION=${LATEST_RELEASE_TAG//fcrepo-/}" >> $GITHUB_ENV
           fi
 
-      - name: Set up JDK 21
+      - name: Set up JDK 11 
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: 21
+          java-version: 11
           cache: "maven"
 
       - name: "Build fcrepo WAR"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:10-jdk21-temurin
+FROM tomcat:9-jdk11-temurin
 
 # escape \
 ENV TOMCAT_USERS_FILE=$CATALINA_HOME/conf/tomcat-users.xml \


### PR DESCRIPTION
takes main and reverts tomcat to version 9 and jdk to 11 for fedora 6 maintenance branch pushes

https://fedora-repository.atlassian.net/browse/FCREPO-4083